### PR TITLE
Added ability to use with webpack

### DIFF
--- a/gulp/bundle.js
+++ b/gulp/bundle.js
@@ -14,7 +14,7 @@ const bundleConfig = {
     paths: {
         'ng2-adal/*': '*',
         '@angular/*': './node_modules/@angular/*',
-        'adal.js': './node_modules/adal-angular/lib/adal.js',
+        'adal-angular': './node_modules/adal-angular/lib/adal.js',
         '*': './node_modules/*'
     },
     packages: {

--- a/gulp/clean.js
+++ b/gulp/clean.js
@@ -2,6 +2,6 @@ const gulp = require('gulp');
 const del = require('del');
 const config = require('./config');
 
-gulp.task('clean:dist', (done) => del([config.PATHS.dist.base], done));
+gulp.task('clean:dist', (done) => del([config.PATHS.dist.base + "/*"], done));
 
 gulp.task('clean', ['clean:dist']);

--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -30,7 +30,7 @@ const taskConfigCjs = $.typescript.createProject(config.PATHS.tsConfig, {
 gulp.task('scripts:cjs', () => {
     const tsResult = gulp.src([config.PATHS.tsSrcFiles, 'typings/index.d.ts'])
         .pipe($.sourcemaps.init())
-        .pipe($.typescript(taskConfigCjs));
+        .pipe(taskConfigCjs());
     return merge([
         tsResult.dts
             .pipe($.header(banner, { pkg: config.pkg })),

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "node": ">=5.0.0"
   },
   "scripts": {
-    "postinstall": "typings install"
+    "postinstall": "typings install",
+    "gulp": "gulp"
   },
   "dependencies": {
     "@angular/common": "^2.0.0",
@@ -42,7 +43,7 @@
   },
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-typescript": "^2.13.6",
+    "gulp-typescript": "^3.1.3",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-header": "^1.8.2",
     "gulp-load-plugins": "^1.2.4",

--- a/src/adal-angular/index.d.ts
+++ b/src/adal-angular/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'adal' {
+declare module 'adal-angular' {
     export function inject(config: adal.Config): adal.AuthenticationContext;
 }
 

--- a/src/services/adal.service.ts
+++ b/src/services/adal.service.ts
@@ -1,12 +1,7 @@
 import {Injectable} from '@angular/core';
-import 'rxjs/Rx';
-import {Observable} from "rxjs/Observable";
-import 'rxjs/observable/bindCallback'
+import { Observable } from 'rxjs';
 import * as adalLib from 'adal-angular';
 import {OAuthData} from "./oauthdata.model";
-
-
-
 
 @Injectable()
 export class AdalService {

--- a/src/services/adal.service.ts
+++ b/src/services/adal.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import 'rxjs/Rx';
 import {Observable} from "rxjs/Observable";
 import 'rxjs/observable/bindCallback'
-import adalLib = require('adal');
+import * as adalLib from 'adal-angular';
 import {OAuthData} from "./oauthdata.model";
 
 

--- a/src/services/authHttp.service.ts
+++ b/src/services/authHttp.service.ts
@@ -1,7 +1,6 @@
 import {Injectable} from '@angular/core';
 import {Http, Response, Headers, RequestOptionsArgs, RequestOptions, RequestMethod, URLSearchParams} from '@angular/http';
-import {Observable} from 'rxjs/Observable';
-import 'rxjs/observable/bindCallback'
+import {Observable} from 'rxjs';
 import {AdalService} from './adal.service';
 
 @Injectable()


### PR DESCRIPTION
- Updated gulp-typescript to use TypeScript 2.x (previously used 1.8.x) and fix syntax errors in RxJS during the build
- Fixed webpack warnings:
> There is another module with an equal name when case is ignored.
> This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
> Rename module if multiple modules are expected or use equal casing if one module is expected.
- Renamed adal to adal-angular to let webpack build run without aliases