### PR TITLE
Fix for refresh ignoring id_token

### DIFF
--- a/src/services/adal.service.ts
+++ b/src/services/adal.service.ts
@@ -78,6 +78,9 @@ export class AdalService {
                         if (requestInfo.parameters['access_token']) {
                             this.adalContext.callback(this.adalContext._getItem(this.adalContext.CONSTANTS.STORAGE.ERROR_DESCRIPTION)
                                 , requestInfo.parameters['access_token']);
+                        } else if (requestInfo.parameters['id_token']) {
+                            this.adalContext.callback(this.adalContext._getItem(this.adalContext.CONSTANTS.STORAGE.ERROR_DESCRIPTION)
+                                , requestInfo.parameters['id_token']);
                         }
                         else if (requestInfo.parameters['error']) {
                             this.adalContext.callback(this.adalContext._getItem(this.adalContext.CONSTANTS.STORAGE.ERROR_DESCRIPTION), null);


### PR DESCRIPTION
Hiya,

I've been working with this library for our Azure Angular application for authentication and I've encountered an issue where the parent window isn't informed of a successful authentication within the iframe that is used for silent authentication.

Upon looking over the code, it looks like adal.js checks for either an access_token or id_token and stores them to allow the continuation of the application. This library appears to ignore the id_token which causes the internal iframe to ignore the callback.

I'm happy to be corrected on this issue and if it turns out to be a configuration issue I'll go ahead and change our code.