### PR TITLE
Make authHttp handleError protected to enable custom catch logic

### DIFF
--- a/src/services/authHttp.service.ts
+++ b/src/services/authHttp.service.ts
@@ -93,7 +93,7 @@ export class AuthHttp {
         return body || {};
     }
 
-    private handleError(error: any) {
+    protected handleError(error: any) {
         // in a real world app, we might send the error to remote logging infrastructure
         console.error(JSON.stringify(error)); // log to console instead
         return Observable.throw(error);


### PR DESCRIPTION
Currently I am not able to catch errors, since you are doing it in your lib. Please either remove the error handling or make it protected, so I can overwrite it. (this one or #50)