### PR TITLE
Don´t log errors to console

### DIFF
--- a/src/services/authHttp.service.ts
+++ b/src/services/authHttp.service.ts
@@ -94,8 +94,6 @@ export class AuthHttp {
     }
 
     private handleError(error: any) {
-        // in a real world app, we might send the error to remote logging infrastructure
-        console.error(JSON.stringify(error)); // log to console instead
         return Observable.throw(error);
     }
 }


### PR DESCRIPTION
I might be wrong but I think it would be better to just return the error and leave all error handling to the client/initiator.

I have a problem right now where I´m calling the User/Photos endpoint of Microsoft Graph API. If a user doesn´t have a photo, the API return an 404 by design (https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/profilephoto_get). In this case I don´t want these 404´s logged to the console.

What do you think?