### PR TITLE
Fix Throw error AuthHttp.service 

### DIFF
--- a/src/services/authHttp.service.ts
+++ b/src/services/authHttp.service.ts
@@ -5,6 +5,7 @@ import {AdalService} from './adal.service';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/observable/throw';
 
 @Injectable()
 export class AuthHttp {


### PR DESCRIPTION
This should fix the 'throw' error ( in the application and not the build) and keeps the size of the lib small.