### PR TITLE
Eliminate dead code in adal.service

### DIFF
--- a/src/services/adal.service.ts
+++ b/src/services/adal.service.ts
@@ -166,16 +166,9 @@ export class AdalService {
         let token = this.adalContext.getCachedToken(resource);
         this.oauthData.isAuthenticated = token !== null && token.length > 0;
         let user = this.adalContext.getCachedUser() || { userName: '', profile: undefined };
-        if (user) {
-            this.oauthData.userName = user.userName;
-            this.oauthData.profile = user.profile;
-            this.oauthData.loginError = this.adalContext.getLoginError();
-        }
-        else {
-            this.oauthData.userName = '';
-            this.oauthData.profile = {};
-            this.oauthData.loginError = '';
-        }
+        this.oauthData.userName = user.userName;
+        this.oauthData.profile = user.profile;
+        this.oauthData.loginError = this.adalContext.getLoginError();
 
     };
 }


### PR DESCRIPTION
The user object is always being defaulted so if (user) will always be true.