### PR TITLE
this was undefined in getUser error handler

### DIFF
--- a/src/services/adal.service.ts
+++ b/src/services/adal.service.ts
@@ -127,7 +127,7 @@ export class AdalService {
 
     public getUser(): Observable<adal.User> {
         return Observable.bindCallback<User>((cb: (u: adal.User) => User) => {
-            this.adalContext.getUser(function (error: string, user: adal.User) {
+            this.adalContext.getUser((error: string, user: adal.User) => {
                 if (error) {
                     this.adalContext.error('Error when getting user', error);
                     cb(null);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "commonjs",
     "target": "es5",
     "noImplicitAny": true,
+    "noImplicitThis": true,
     "experimentalDecorators": true,
     "outDir": "dist/",
     "rootDir": "src/",


### PR DESCRIPTION
you get here when calling getUser() before logging in. The adal library then throws 'User information is not available' string.

One could argue that ng2-adal should even catch the 'User information is not available' and emit `undefined` from the Observable. Once the user logs in the Observable will emit the User object. To me that feels more how an Observable should work. But for now, I just fixed the error handling code so the 'User information is not available' string is at least re-thrown so I can catch that in my own Observable (and emit `undefined`). With the current implementation the ng2-adal library throws a TypeError as this.adalContext is undefined in the error handler